### PR TITLE
Fixed uncaught ReferenceError while using the Message Template feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the node-red-contrib-dynamic-websocket project will be do
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-04-27
+
+### Fixed
+- Fixed un-caught `ReferenceError: node is not defined` when using `Transform Message` feature.
+
 ## [1.1.0] - 2025-12-15
 
 ### Fixed

--- a/dynamic-websocket.js
+++ b/dynamic-websocket.js
@@ -206,6 +206,63 @@ module.exports = function(RED) {
             });
         }
 
+        // Function to transform messages based on selected format and template
+        function transformMessage(message) {
+            try {
+                // Skip transformation for null or undefined messages
+                if (message === null || message === undefined) {
+                    return null;
+                }
+                
+                // Apply template if available
+                if (Object.keys(node.messageTemplate).length > 0) {
+                    let result = JSON.parse(JSON.stringify(node.messageTemplate)); // Clone template
+                    
+                    // Simple placeholder replacement for string values
+                    function replaceValues(obj, data) {
+                        for (let key in obj) {
+                            if (typeof obj[key] === 'string' && obj[key].startsWith('$')) {
+                                const placeholder = obj[key].substring(1); // Remove $ prefix
+                                if (data[placeholder] !== undefined) {
+                                    obj[key] = data[placeholder];
+                                }
+                            } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+                                replaceValues(obj[key], data);
+                            }
+                        }
+                        return obj;
+                    }
+                    
+                    result = replaceValues(result, message);
+                    
+                    // Validate message if validation is enabled
+                    if (node.validateMessages) {
+                        // Implement validation logic based on message format
+                        // For now, just check if required fields are present
+                        let valid = true;
+                        for (let key in result) {
+                            if (result[key] === undefined || result[key] === null) {
+                                valid = false;
+                                node.warn("Message validation failed: Missing required field '" + key + "'");
+                                break;
+                            }
+                        }
+                        if (!valid) {
+                            return null;
+                        }
+                    }
+                    
+                    return result;
+                } else {
+                    // No template, just return the original message
+                    return message;
+                }
+            } catch (e) {
+                node.warn("Message transformation failed: " + e.message);
+                return null;
+            }
+        }
+
         // Connect on startup if URL is set
         if (node.url) {
             connectWebSocket(node.url);
@@ -360,63 +417,6 @@ module.exports = function(RED) {
             }
             done();
         });
-    }
-
-    // Function to transform messages based on selected format and template
-    function transformMessage(message) {
-        try {
-            // Skip transformation for null or undefined messages
-            if (message === null || message === undefined) {
-                return null;
-            }
-            
-            // Apply template if available
-            if (Object.keys(node.messageTemplate).length > 0) {
-                let result = JSON.parse(JSON.stringify(node.messageTemplate)); // Clone template
-                
-                // Simple placeholder replacement for string values
-                function replaceValues(obj, data) {
-                    for (let key in obj) {
-                        if (typeof obj[key] === 'string' && obj[key].startsWith('$')) {
-                            const placeholder = obj[key].substring(1); // Remove $ prefix
-                            if (data[placeholder] !== undefined) {
-                                obj[key] = data[placeholder];
-                            }
-                        } else if (typeof obj[key] === 'object' && obj[key] !== null) {
-                            replaceValues(obj[key], data);
-                        }
-                    }
-                    return obj;
-                }
-                
-                result = replaceValues(result, message);
-                
-                // Validate message if validation is enabled
-                if (node.validateMessages) {
-                    // Implement validation logic based on message format
-                    // For now, just check if required fields are present
-                    let valid = true;
-                    for (let key in result) {
-                        if (result[key] === undefined || result[key] === null) {
-                            valid = false;
-                            node.warn("Message validation failed: Missing required field '" + key + "'");
-                            break;
-                        }
-                    }
-                    if (!valid) {
-                        return null;
-                    }
-                }
-                
-                return result;
-            } else {
-                // No template, just return the original message
-                return message;
-            }
-        } catch (e) {
-            node.warn("Message transformation failed: " + e.message);
-            return null;
-        }
     }
     
     RED.nodes.registerType("dynamic-websocket", DynamicWebSocketNode, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-dynamic-websocket",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A node that dynamically connects to a WebSocket URL, can send and receive messages, and reports connection state changes.",
   "keywords": ["node-red", "websocket", "dynamic", "web-socket", "dynamic-websocket"],
   "node-red": {


### PR DESCRIPTION
There's a bug in the package which produces an uncaught runtime error: `ReferenceError: node is not defined.` when using the `Message Template` feature.

It is caused due to a scoping issue where the `node` variable is defined inside the `DynamicWebSocketNode` but the `transformMessage` is implemented outside the `DynamicWebSocketNode` function. When the `transformMessage` tries to reference the `node` variable which in it's scope doesn't exist, it throws the runtime reference error (it escapes the `catch` clause too because the `catch` clause is also referencing the `node` variable which in-turn throws another reference error).

Fix: Just move the function inside the `DynamicWebSocketNode` function.